### PR TITLE
Fix bug with allocate memory

### DIFF
--- a/src/java/nanomsg/Socket.java
+++ b/src/java/nanomsg/Socket.java
@@ -299,29 +299,49 @@ public abstract class Socket {
     return fd.getValue();
   }
 
-  /**
-   * Set send timeout option to the socket.
-   */
-  public synchronized void setSendTimeout(final int milis) {
-    final int socket = getNativeSocket();
+    /**
+     * Set send timeout option to the socket.
+     */
+    public synchronized void setSendTimeout(final int milis) {
+        final int socket = getNativeSocket();
 
-    Memory ptr = new Memory(Native.SIZE_T_SIZE/2);
-    ptr.setInt(0, milis);
+        NativeLibrary.nn_setsockopt(socket, Nanomsg.constants.NN_SOL_SOCKET,
+                Nanomsg.constants.NN_SNDTIMEO, newSizeT(milis), Native.SIZE_T_SIZE);
+    }
 
-    final int rc = NativeLibrary.nn_setsockopt(socket, Nanomsg.constants.NN_SOL_SOCKET,
-                                               Nanomsg.constants.NN_SNDTIMEO, ptr, Native.SIZE_T_SIZE/2);
-  }
+    /**
+     * Set recv timeout option to the socket.
+     */
+    public synchronized void setRecvTimeout(int milis) {
+        final int socket = getNativeSocket();
 
-  /**
-   * Set recv timeout option to the socket.
-   */
-  public synchronized void setRecvTimeout(int milis) {
-    final int socket = getNativeSocket();
+        NativeLibrary.nn_setsockopt(socket, Nanomsg.constants.NN_SOL_SOCKET,
+                Nanomsg.constants.NN_RCVTIMEO, newSizeT(milis), Native.SIZE_T_SIZE);
+    }
 
-    Memory ptr = new Memory(Native.SIZE_T_SIZE/2);
-    ptr.setInt(0, milis);
+    /**
+     * Set memory.
+     * @param ptr pointer.
+     * @param value timeout.
+     */
+    private static void setSizeT(Memory ptr, long value)
+    {
+        if (Native.SIZE_T_SIZE == 8)
+            ptr.setLong(0, value);
+        else
+            ptr.setInt(0, (int)value);
+    }
 
-    final int rc = NativeLibrary.nn_setsockopt(socket, Nanomsg.constants.NN_SOL_SOCKET,
-                                               Nanomsg.constants.NN_RCVTIMEO, ptr, Native.SIZE_T_SIZE/2);
-  }
+    /**
+     * Pointer with allocated memory.
+     * @param value value.
+     * @return Memory pointer.
+     */
+    private Memory newSizeT(long value)
+    {
+        Memory ptr = new Memory(Native.SIZE_T_SIZE);
+        setSizeT(ptr, value);
+
+        return ptr;
+    }
 }


### PR DESCRIPTION
I find another bug.
If we use 64bit OS - it's all ok.
But if we use the 32bit - it's not working.
Why?
Size_t on win32 - 4, on win64 and linux64 - 8.
If we use 64 bit OS - we should use .setLong(...)
Else  - setInt(...)

And i add a two methods, which allocate memory and remove some duplicate lines.
I test it on win32, win64 and linux64.
What are you thinking about it?